### PR TITLE
Update ruff config & `CODEOWNERS`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,3 @@
 # Syntax for this file at https://help.github.com/articles/about-codeowners/
 
-*       @conda/conda-dot-org
-*       @conda/communications
+*       @conda/conda-dot-org @conda/communications

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.codespell]
 ignore-words-list = "lief,repet"
 
-[tool.ruff]
+[tool.ruff.lint]
 # E, W = pycodestyle errors and warnings
 # F = pyflakes
 # I = isort


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy choices to be aware of,
       - or what the problem resolved here looked like. -->

Found while working on #213 that as `CODEOWNERS` is currently defined we are required to have approvals from both @conda/conda-dot-org **AND** @conda/communications teams. We actually want it to be one **OR** the other.

Also correcting `pyproject.toml`'s ruff config based on my IDE lints.

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     If you are contributing content to parts of the website that are not
     the blog, remember that this content is not meant to prioritize any
     single tool, project, company or organization. The blog is a place
     where we are allowed to be more opinionated and promote these things.

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regard to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->

- [ ] If I have added a new page to `learn/` or `community/`, I have added it to the corresponding `_sidebar.json` file.
