### PR TITLE
Replace matrix links with zulip links

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 This is the repository for the conda.org community website. To become involved:
 
-- Join the [conda.org chat room](https://app.element.io/#/room/#conda.org:matrix.org), which is part of the [conda space on Matrix](https://app.element.io/#/room/#conda:matrix.org)
+- Join the [conda-dot-org channel](https://conda.zulipchat.com/#narrow/channel/471465-conda-dot-org), which is part of the [conda organization on Zulip(https://conda.zulipchat.com)
 - Visit the [Root HackMD page](https://hackmd.io/DGtozSlsSjSokpYAK5-9hw), which links to everything in HackMD.
-- We meet every two weeks on Monday at 9am US Central time / 16:00 Central European Time. Please join the [Matrix room](https://app.element.io/#/room/#conda.org:matrix.org) and we will invite you.
+- We meet every two weeks on Monday at 9am US Central time / 16:00 Central European Time. Please join the [Zulip channel](https://conda.zulipchat.com/#narrow/channel/471465-conda-dot-org) and we will invite you.
 
 ## Code of Conduct
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ This is the repository for the conda.org community website. To become involved:
 
 - Join the [conda-dot-org channel](https://conda.zulipchat.com/#narrow/channel/471465-conda-dot-org), which is part of the [conda organization on Zulip(https://conda.zulipchat.com)
 - Visit the [Root HackMD page](https://hackmd.io/DGtozSlsSjSokpYAK5-9hw), which links to everything in HackMD.
-- We meet every two weeks on Monday at 9am US Central time / 16:00 Central European Time. Please join the [Zulip channel](https://conda.zulipchat.com/#narrow/channel/471465-conda-dot-org) and we will invite you.
 
 ## Code of Conduct
 

--- a/community/index.mdx
+++ b/community/index.mdx
@@ -33,7 +33,7 @@ title: Conda Community
 <!-- Chat services -->
 
 [conda-zulip]: https://conda.zulipchat.com
-[conda-forge-element]: http://bit.ly/cf-chat-space
+[conda-forge-zulip]: https://conda-forge.zulipchat.com/
 [mamba-gitter]: https://gitter.im/mamba-org/Lobby
 
 <!-- Misc. -->
@@ -78,10 +78,10 @@ See above for a list of GitHub organizations.
 
 ### Chat
 
-Many projects also use chat platforms such as Element to organize development efforts or to enable the community to provide better support. Below are some of the known chat servers within the conda community:
+Many projects also use chat platforms, such as Zulip, to organize development efforts or to enable the community to provide better support. Below are some of the known chat servers within the conda community:
 
 - [conda on Zulip][conda-zulip]
-- [conda-forge on Element][conda-forge-element]
+- [conda-forge on Zulip][conda-forge-zulip]
 - [mamba on Gitter][mamba-gitter]
 
 ### Discourse

--- a/community/index.mdx
+++ b/community/index.mdx
@@ -32,7 +32,7 @@ title: Conda Community
 
 <!-- Chat services -->
 
-[conda-element]: http://bit.ly/conda-chat-room
+[conda-zulip]: https://conda.zulipchat.com
 [conda-forge-element]: http://bit.ly/cf-chat-space
 [mamba-gitter]: https://gitter.im/mamba-org/Lobby
 
@@ -80,7 +80,7 @@ See above for a list of GitHub organizations.
 
 Many projects also use chat platforms such as Element to organize development efforts or to enable the community to provide better support. Below are some of the known chat servers within the conda community:
 
-- [conda on Element][conda-element]
+- [conda on Zulip][conda-zulip]
 - [conda-forge on Element][conda-forge-element]
 - [mamba on Gitter][mamba-gitter]
 
@@ -104,7 +104,7 @@ project, we encourage you to visit their respective project websites (see above)
 
 Contributing to this website, either in the form of a blog post or feature addition can be
 done via our [GitHub project page][conda-dot-org]. Please also feel free to reach out to
-us via our [Element chat room][conda-element].
+us via our [Zulip chat room][conda-zulip].
 
 We look forward to hearing from you and your contributions!
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Closes https://github.com/conda/conda-dot-org/issues/230.

We're moving away from Matrix and towards Zulip, so I've updated all relevant links to their Zulip equivalents.

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     If you are contributing content to parts of the website that are not
     the blog, remember that this content is not meant to prioritize any
     single tool, project, company or organization. The blog is a place
     where we are allowed to be more opinionated and promote these things.

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regard to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->

- ~[ ] If I have added a new page to `learn/` or `community/`, I have added it to the corresponding `_sidebar.json` file.~
