### PR TITLE
Mark `.mdx` as documentation file type

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.mdx linguist-documentation


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy choices to be aware of,
       - or what the problem resolved here looked like. -->

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     If you are contributing content to parts of the website that are not
     the blog, remember that this content is not meant to prioritize any
     single tool, project, company or organization. The blog is a place
     where we are allowed to be more opinionated and promote these things.

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regard to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->

- [ ] If I have added a new page to `learn/` or `community/`, I have added it to the corresponding `_sidebar.json` file.


Should help with the bad syntax highlighting seen in, e.g.,  blog post PRs: https://github.com/conda/conda-dot-org/pull/258/files