### PR TITLE
Clarify Nix comparison details in Part 2 of the 'Conda Is Not PyPI' series

### DIFF
--- a/blog/2025-11-04-conda-pip-docker-nix.mdx
+++ b/blog/2025-11-04-conda-pip-docker-nix.mdx
@@ -75,7 +75,7 @@ Both **conda packages** and **Nix** instrument builds so binaries are **prefix-a
 - **[Mach-O](https://en.wikipedia.org/wiki/Mach-O) (macOS) fix-ups** (`install_name_tool`) for `LC_LOAD_DYLIB`/`LC_ID_DYLIB`
 - **[ELF](https://en.wikipedia.org/wiki/Executable_and_Linkable_Format) surgery via [`patchelf`](https://github.com/NixOS/patchelf)**, which originated in the Nix ecosystem and is widely used by `conda-build` and `rattler-build`.
 
-The result is the same idea in both worlds: build products that **bind to their own prefix**. In Nix, binaries are patched once to live under fixed, hash-addressed store paths like `/nix/store/...` (typically hashes of the derivation inputs and locked dependency graph, with pure content hashes used mainly for fetched sources) and are not meant to be moved afterwards. In conda, binaries are typically built with a placeholder and relocated dynamically at install time into the environment prefix, so relocatable prefixes are a design objective there.
+The result is the same idea in both worlds: build products that **bind to their own prefix**. In Nix, binaries are patched once to live under fixed, hash-addressed store paths like `/nix/store/...` (typically hashes of the derivation inputs and locked dependency graph, with pure content hashes used mainly for fetched sources) and are not meant to be moved afterwards, since changing the prefix effectively creates a new package identity and bypasses existing binary caches. In conda, binaries are typically built with a placeholder and relocated dynamically at install time into the environment prefix, so relocatable prefixes are a design objective there.
 
 ---
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

This PR makes small wording clarifications in the Part 2 blog post:
- Clarifies Nix’s “relocated once” behavior vs conda’s relocatable prefixes  
- Distinguishes Nix input/derivation hashes from pure content hashes  
- Narrows the glibc comparison to “conda reuses host libc” vs “Nix/containers ship their own”  
- Refines the “system-wide setup” statement for Nix to describe the typical multi-user install  

No structural changes, just sharper wording based on reviewer feedback.

Thanks @mmesch for the detailed feedback from the Nix perspective 

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy choices to be aware of,
       - or what the problem resolved here looked like. -->

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     If you are contributing content to parts of the website that are not
     the blog, remember that this content is not meant to prioritize any
     single tool, project, company or organization. The blog is a place
     where we are allowed to be more opinionated and promote these things.

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regard to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->

- [ ] If I have added a new page to `learn/` or `community/`, I have added it to the corresponding `_sidebar.json` file.
