### PR TITLE
Fix menuinst osx platform key reference

### DIFF
--- a/learn/specifications/packages/menu.md
+++ b/learn/specifications/packages/menu.md
@@ -186,7 +186,7 @@ simplified overview of all possible keys and their default values:
 }
 ```
 
-Note that each `platforms` sub-dictionary (`linux`, `macos`, `win`) can override the global values
+Note that each `platforms` sub-dictionary (`linux`, `osx`, `win`) can override the global values
 of their `menu_items[*]` entry (e.g. redefining `command` to adjust the shell syntax).
 
 Each JSON file MUST be validated against its `$id` schema at build time; e.g in `conda-build`.

--- a/learn/specifications/packages/menu.md
+++ b/learn/specifications/packages/menu.md
@@ -124,7 +124,7 @@ simplified overview of all possible keys and their default values:
       "activate": true,  # activate conda environment before running 'command'
       "terminal": false, # open in terminal and leave it open
       "platforms": {
-        # To create the menu item for a fiven platform, the key must be present in this
+        # To create the menu item for a given platform, the key must be present in this
         # dictionary. Presence is enough; the value can just be the empty dictionary: {}.
         "linux": {
           # See XDG Desktop standard for details


### PR DESCRIPTION
This fixes two small typos in the `Menu/` package specification page.

The main change is in the `menuinst 2.x` section. The simplified schema uses `osx` as the macOS platform key, but the explanatory text referred to `macos`. Since the schema only accepts `linux`, `osx`, and `win` under platforms, this could be confusing for readers writing or validating `Menu/*.json` files.

I also fixed a nearby typo in a schema comment: `fiven` -> `given`.

No new pages were added.

- [ ] If I have added a new page to `learn/` or `community/`, I have added it to the corresponding `_sidebar.json` file.
